### PR TITLE
fixed template path for issue #12

### DIFF
--- a/pyhelm/chartbuilder.py
+++ b/pyhelm/chartbuilder.py
@@ -151,8 +151,7 @@ class ChartBuilder(object):
                                                    'templates'), topdown=True):
             for tpl_file in files:
                 tname = os.path.relpath(os.path.join(root, tpl_file),
-                                        os.path.join(self.source_directory,
-                                                     'templates'))
+                                        self.source_directory)
 
                 templates.append(Template(name=tname,
                                           data=open(os.path.join(root,


### PR DESCRIPTION
There was a path mismatch in $Template.Basepath and paths in 
`/pyhelm/chartbuilder.py:153`
#12 