### PR TITLE
Do not pin dependency versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ run_tests.err.log
 doc/source/api
 doc/build
 *.egg
+*.egg-info
 .eggs/*
 # Files created by releasenotes build
 releasenotes/build

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-gitpython==2.1.10
-grpcio==1.1.3
-grpcio-tools==1.1.3
-protobuf==3.2.0
-supermutes==0.2.5
-requests==2.14.2
-PyYAML==3.12
+gitpython
+grpcio
+grpcio-tools
+protobuf
+supermutes
+requests
+PyYAML

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,2 @@
-flake8==3.3.0
-tox==2.6.0
+flake8
+tox


### PR DESCRIPTION
Pinning dependency versions in libraries can cause dependency hell.