### PR TITLE
Adding simple support for S3 backed repositories

### DIFF
--- a/pyhelm/repo.py
+++ b/pyhelm/repo.py
@@ -2,24 +2,83 @@ import cStringIO
 import itertools
 import os
 from git import Repo
+from urlparse import urlparse
 import requests
 import shutil
 import tarfile
 import tempfile
 import yaml
+import boto3.s3
+from botocore.exceptions import ClientError
 
 
-def repo_index(repo_url, headers=None):
+def _get_from_http(repo_url, file_url):
+    """Downloads the Chart's repo index from HTTP(S)"""
+    
+    if repo_url not in file_url:
+        file_url = os.path.join(repo_url, file_url)
+
+    index = requests.get(file_url)
+    return index.content
+
+def _get_from_s3(repo_url, file_url):
+    """Download the index / Chart from S3 bucket"""
+
+    s3_client = boto3.client('s3')
+
+    # NOTE(ljakimczuk): this is done for two
+    # reasons. First, it allows to use this
+    # function for either getting index.yaml
+    # or Chart. Second, at least the Chartmuseum-
+    # generated index.yaml may have the relative
+    # URLs (guess due to its multi-tenancy), so
+    # turning them into absolute is needed.
+    if repo_url not in file_url:
+        file_url = os.path.join(repo_url, file_url)
+    
+    file_url_parsed = urlparse(file_url)
+
+    try:
+        file_object = s3_client.get_object(
+            Bucket=file_url_parsed.netloc,
+            Key=file_url_parsed.path.strip('/'),
+        )
+
+        return file_object['Body'].read()
+    except ClientError as e:
+        if e.response['Error']['Code'] == 'NoSuchBucket':
+            raise RuntimeError('%s repository not found' % file_url_parsed.netloc)
+        elif e.response['Error']['Code'] == 'NoSuchKey':
+            raise RuntimeError('%s not found in the repository' % file_url_parsed.path.strip('/'))
+        else:
+            pass
+
+def repo_index(repo_url):
     """Downloads the Chart's repo index"""
-    index_url = os.path.join(repo_url, 'index.yaml')
-    index = requests.get(index_url, headers=headers)
-    return yaml.load(index.content)
+    repo_scheme = urlparse(repo_url).scheme
 
+    if repo_scheme == 's3':
+        return yaml.load(
+            _get_from_s3(
+                repo_url,
+                'index.yaml',
+            )
+        )
+    elif repo_scheme in ('http', 'https'):
+        return yaml.load(
+            _get_from_http(
+                repo_url,
+                'index.yaml',
+            )
+        )
+    else:
+        raise RuntimeError('The %s repository not supported' % repo_scheme.upper())
 
 def from_repo(repo_url, chart, version=None, headers=None):
     """Downloads the chart from a repo."""
     _tmp_dir = tempfile.mkdtemp(prefix='pyhelm-', dir='/tmp')
-    index = repo_index(repo_url, headers)
+    repo_scheme = urlparse(repo_url).scheme
+    index = repo_index(repo_url)
 
     if chart not in index['entries']:
         raise RuntimeError('Chart not found in repo')
@@ -29,14 +88,28 @@ def from_repo(repo_url, chart, version=None, headers=None):
     if version is not None:
         versions = itertools.ifilter(lambda k: k['version'] == version,
                                      versions)
-
     try:
         metadata = sorted(versions, key=lambda x: x['version'])[0]
         for url in metadata['urls']:
             fname = url.split('/')[-1]
             try:
-                req = requests.get(url, stream=True, headers=headers)
-                fobj = cStringIO.StringIO(req.content)
+                if repo_scheme == 's3':
+                    fobj = cStringIO.StringIO(
+                        _get_from_s3(
+                            repo_url,
+                            url,
+                        )
+                    )
+                elif repo_scheme in ('http', 'https'):
+                    fobj = cStringIO.StringIO(
+                        _get_from_http(
+                            repo_url,
+                            url,
+                        )
+                    )
+                else:
+                    raise RuntimeError('The %s repository not supported' % repo_scheme.upper())
+
                 tar = tarfile.open(mode="r:*", fileobj=fobj)
                 tar.extractall(_tmp_dir)
                 return os.path.join(_tmp_dir, chart)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,6 @@ protobuf
 supermutes
 requests
 PyYAML
+boto3
+botocore
+


### PR DESCRIPTION
Hi! I'd like to add support for the S3-backed repositories.

Well, if this is not the best way of doing this, please share with me any suggestions and I would gladly put fixes. My way of thinking was simple, at the beginning I thought of separating the `repo_index` and the `from_repo` into something like `[ s3 | http ]_repo_index` and `from_[ s3 | http ]_repo` in order to somehow highlight the difference between the two back-ends. Then, I imagined from the user's perspective it may be smoother to be allowed to stick to the `repo_index` and the `from_repo` and then just feed them with the new URL, instead of being introduced with new interfaces. In result, I move the fetching of index/Charts into the `_get` functions.

One more think to mention, at least the Chartmuseum's `index.yaml` may only have the relative URLs instead of absolute ones. This is one of the two reasons for the extra `if` and `join`.