### PR TITLE
Fix a typo with repo.py

### DIFF
--- a/pyhelm/chartbuilder.py
+++ b/pyhelm/chartbuilder.py
@@ -82,7 +82,8 @@ class ChartBuilder(object):
         elif self.chart.source.type == 'repo':
             self._source_tmp_dir = repo.from_repo(self.chart.source.location,
                                                   self.chart.name,
-                                                  self.chart.version)
+                                                  self.chart.version,
+                                                  self.chart.source.headers)
         elif self.chart.source.type == 'directory':
             self._source_tmp_dir = self.chart.source.location
 

--- a/pyhelm/repo.py
+++ b/pyhelm/repo.py
@@ -9,17 +9,17 @@ import tempfile
 import yaml
 
 
-def repo_index(repo_url):
+def repo_index(repo_url, headers=None):
     """Downloads the Chart's repo index"""
     index_url = os.path.join(repo_url, 'index.yaml')
-    index = requests.get(index_url)
+    index = requests.get(index_url, headers=headers)
     return yaml.load(index.content)
 
 
-def from_repo(repo_url, chart, version=None):
+def from_repo(repo_url, chart, version=None, headers=None):
     """Downloads the chart from a repo."""
     _tmp_dir = tempfile.mkdtemp(prefix='pyhelm-', dir='/tmp')
-    index = repo_index(repo_url)
+    index = repo_index(repo_url, headers)
 
     if chart not in index['entries']:
         raise RuntimeError('Chart not found in repo')
@@ -35,7 +35,7 @@ def from_repo(repo_url, chart, version=None):
         for url in metadata['urls']:
             fname = url.split('/')[-1]
             try:
-                req = requests.get(url, stream=True)
+                req = requests.get(url, stream=True, headers=headers)
                 fobj = cStringIO.StringIO(req.content)
                 tar = tarfile.open(mode="r:*", fileobj=fobj)
                 tar.extractall(_tmp_dir)

--- a/pyhelm/repo.py
+++ b/pyhelm/repo.py
@@ -18,7 +18,7 @@ def repo_index(repo_url, headers=None):
 
 def from_repo(repo_url, chart, version=None, headers=None):
     """Downloads the chart from a repo."""
-    _tmp_dir = tempfile.mkdtemp(prefix='pyhelm-', dir='/tmp')
+    _tmp_dir = tempfile.mkdtemp(prefix='pyhelm-')
     index = repo_index(repo_url, headers)
 
     if chart not in index['entries']:

--- a/pyhelm/repo.py
+++ b/pyhelm/repo.py
@@ -106,7 +106,7 @@ def from_repo(repo_url, chart, version=None, headers=None):
                     _get_from_repo(
                         repo_scheme,
                         repo_url,
-                        url,
+                        fname,
                         stream=True,
                         headers=headers,
                     )


### PR DESCRIPTION
I was using the master branch, but it broke my code because "_get_from_repo" return None for some reason. Then I took some time to debug and realized there is a typo inside from_repo. Then I found the problem: the 'url' for _get_from_repo should be a file name, which is fname!

In addition, in my early debugging, I though it was because "_get_from_repo" is not able to create "/tmp" folder. So I deleted '/tmp'. By deleting it, the mktempfile will generate a folder in the system's default temp folder which varies from platform to platform. This could avoid future permission issue.

I also put the importing of boto3 and botocore to the function who uses them. Because for a person like me, who uses this library in IBM Cloud, I don't want to import them. 

Let me know what you think.

Thanks @flaper87 @yanivoliver 