### PR TITLE
Use full URL from metadata

### DIFF
--- a/pyhelm/repo.py
+++ b/pyhelm/repo.py
@@ -100,13 +100,12 @@ def from_repo(repo_url, chart, version=None, headers=None):
     try:
         metadata = sorted(versions, key=lambda x: x['version'])[0]
         for url in metadata['urls']:
-            fname = url.split('/')[-1]
             try:
                 fobj = cStringIO.StringIO(
                     _get_from_repo(
                         repo_scheme,
                         repo_url,
-                        fname,
+                        url,
                         stream=True,
                         headers=headers,
                     )


### PR DESCRIPTION
Truncating the URL will fail for repositories where the charts are not directly under the root URL, e.g.:
```
# URL of the chart is http://chartmuseum.localdomain/charts/mychart
from_repo('http://chartmuseum.localdomain', 'mychart') == None
```

If this truncation is necessary for S3 retrieval, I'll think of something else.