### PR TITLE
Better way of verifying the URLs from index.yaml

### DIFF
--- a/pyhelm/repo.py
+++ b/pyhelm/repo.py
@@ -102,12 +102,11 @@ def from_repo(repo_url, chart, version=None, headers=None):
     try:
         metadata = sorted(versions, key=lambda x: list(map(int, x['version'].split('.'))))[-1]
         for url in metadata['urls']:
-            fname = url.split('/')[-1]
             fobj = cStringIO.StringIO(
                 _get_from_repo(
                     repo_scheme,
                     repo_url,
-                    fname,
+                    url,
                     stream=True,
                     headers=headers,
                 )


### PR DESCRIPTION
This is related to the #30 and #36. For some reason in some case the code was not able to produce the valid URL for downloading the Chart and in result the `fname` was introduced by the #30. However, using the `fname` violates the rules of how charts are located by the client - this location is normally known to the `index.yaml` and given to the client by `url`, it is not known by the client beforehand. After the change, the knowledge of the `index.yaml` is ignored causing the code to produce the wrong URLs for charts (#36).

While the discussion taken in the #30 is still open IMHO, since we didn't identify the root cause of the problem, I could think of at least two possible reasons with one of them being the `if` statement poorly written by me in one of the previous PRs. This PR should introduce better checking for absolute URLs. For the record, the last time I assumed that the URLs from the `index.yaml`, if absolute, are the same as the Helm repository URL, but that is not necessarily the case. I could imagine the index being created with different absolute URLs for its Charts than the actual repository URL known to Helm. In such case the previous `if` would wrongly assume the absolute URLs from the `index.yaml` are relative.

In addition I would vote for continuing and solving the discussion from the #30 and then changing the #36 accordingly in order to make the PyHelm fully operational again, not serving only some of the cases at the cost of the general ones.