### PR TITLE
Add explicit reference for logger

### DIFF
--- a/pyhelm/chartbuilder.py
+++ b/pyhelm/chartbuilder.py
@@ -116,7 +116,7 @@ class ChartBuilder(object):
         Process metadata
         '''
         # extract Chart.yaml to construct metadata
-        chart_yaml = dotify(yaml.load(pathlib.Path(self.source_directory, 'Chart.yaml').read_text())
+        chart_yaml = dotify(yaml.load(pathlib.Path(self.source_directory, 'Chart.yaml').read_text()))
 
         # construct Metadata object
         return Metadata(

--- a/pyhelm/chartbuilder.py
+++ b/pyhelm/chartbuilder.py
@@ -1,16 +1,16 @@
-import logger
 import os
+
 import yaml
-
-from hapi.services.tiller_pb2 import GetReleaseContentRequest
-from hapi.chart.template_pb2 import Template
-from hapi.chart.chart_pb2 import Chart
-from hapi.chart.metadata_pb2 import Metadata
-from hapi.chart.config_pb2 import Config
 from google.protobuf.any_pb2 import Any
-
-from pyhelm import repo
 from supermutes.dot import dotify
+
+import pyhelm.logger as logger
+from hapi.chart.chart_pb2 import Chart
+from hapi.chart.config_pb2 import Config
+from hapi.chart.metadata_pb2 import Metadata
+from hapi.chart.template_pb2 import Template
+from hapi.services.tiller_pb2 import GetReleaseContentRequest
+from pyhelm import repo
 
 
 class ChartBuilder(object):
@@ -211,7 +211,7 @@ class ChartBuilder(object):
         dependencies = []
 
         for chart in self.chart.get('dependencies', []):
-            self._logger.info("Building dependency chart %s for release %s", 
+            self._logger.info("Building dependency chart %s for release %s",
                               chart.name, self.chart.name)
             dependencies.append(ChartBuilder(chart).get_helm_chart())
 

--- a/pyhelm/chartbuilder.py
+++ b/pyhelm/chartbuilder.py
@@ -116,7 +116,7 @@ class ChartBuilder(object):
         Process metadata
         '''
         # extract Chart.yaml to construct metadata
-        chart_yaml = dotify(yaml.load(pathlib.Path(self.source_directory) / 'Chart.yaml').read_text())
+        chart_yaml = dotify(yaml.load(pathlib.Path(self.source_directory, 'Chart.yaml').read_text())
 
         # construct Metadata object
         return Metadata(
@@ -134,8 +134,7 @@ class ChartBuilder(object):
         #                    (https://github.com/helm/helm/blob/master/pkg/chartutil/load.go)
         chart_files = []
 
-        files = []
-        template_dir = pathlib.Path(self.source_directory) / 'templates'
+        template_dir = pathlib.Path(self.source_directory, 'templates')
 
         if not template_dir.exists():
             self._logger.warn("Chart %s has no templates directory, no templates will be deployed", self.chart.name)
@@ -161,7 +160,7 @@ class ChartBuilder(object):
         Return the chart (default) values
         '''
 
-        values_path = pathlib.Path(self.source_directory) / 'values.yaml'
+        values_path = pathlib.Path(self.source_directory, 'values.yaml')
 
         if not values_path.exists():
             self._logger.warn("No values.yaml in %s, using empty values",
@@ -180,7 +179,7 @@ class ChartBuilder(object):
         # process all files in templates/ as a template to attach to the chart
         # building a Template object
         templates = []
-        template_dir = pathlib.Path(self.source_directory) / 'templates'
+        template_dir = pathlib.Path(self.source_directory, 'templates')
 
         if not template_dir.exists():
             self._logger.warn("Chart %s has no templates directory, no templates will be deployed", self.chart.name)

--- a/pyhelm/repo.py
+++ b/pyhelm/repo.py
@@ -1,4 +1,3 @@
-
 try:
     # Python 3
     from urllib.parse import urlparse

--- a/pyhelm/repo.py
+++ b/pyhelm/repo.py
@@ -1,13 +1,22 @@
-import cStringIO
+try:
+    from io import StringIO
+except ImportError:
+    import cStringIO as StringIO
+
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
+
 import itertools
 import os
-from git import Repo
-from urlparse import urlparse
-import requests
 import shutil
 import tarfile
 import tempfile
+
+import requests
 import yaml
+from git import Repo
 
 
 class HTTPGetError(RuntimeError):
@@ -130,13 +139,16 @@ def from_repo(repo_url, chart, version=None, headers=None):
     try:
         metadata = sorted(versions, key=_semver_sorter)[-1]
         for url in metadata['urls']:
-            fobj = cStringIO.StringIO(
-                _get_from_repo(
-                    repo_scheme,
-                    repo_url,
-                    url,
-                    stream=True,
-                    headers=headers,
+            fname = url.split('/')[-1]
+            try:
+                fobj = StringIO.StringIO(
+                    _get_from_repo(
+                        repo_scheme,
+                        repo_url,
+                        fname,
+                        stream=True,
+                        headers=headers,
+                    )
                 )
             )
 

--- a/pyhelm/tiller.py
+++ b/pyhelm/tiller.py
@@ -1,12 +1,13 @@
 import grpc
 import yaml
-import logger
 
-from hapi.services.tiller_pb2 import ReleaseServiceStub, ListReleasesRequest, \
-    InstallReleaseRequest, UpdateReleaseRequest, UninstallReleaseRequest, \
-    GetReleaseStatusRequest, GetReleaseContentRequest
-from hapi.chart.chart_pb2 import Chart
+import pyhelm.logger as logger
 from hapi.chart.config_pb2 import Config
+from hapi.chart.chart_pb2 import Chart
+
+from hapi.services.tiller_pb2 import GetReleaseContentRequest, GetReleaseStatusRequest, InstallReleaseRequest, \
+    ListReleasesRequest, ReleaseServiceStub, UninstallReleaseRequest, UpdateReleaseRequest
+
 
 TILLER_PORT = 44134
 TILLER_VERSION = b'2.11'

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@ requests
 PyYAML
 boto3
 botocore
+pathlib2; python_version=='2.7'
 


### PR DESCRIPTION
Just tried to start using this and it seems to be trying to import logger from a global namespace. I've made this explicit to import it from pyhelm itself.

I've only tested this on Python 3 but off the top of my head I don't see any forseen compatibility issues. I'm not sure if there are tests somewhere I can run? I've not gotten my head specifically into it rather fixed the bug my end.