### PR TITLE
Ignore non-numeric/dot characters in semver_sorter

### DIFF
--- a/pyhelm/repo.py
+++ b/pyhelm/repo.py
@@ -46,7 +46,7 @@ class RepositoryError(RuntimeError):
 
 
 def _semver_sorter(x):
-    return list(map(int, x['version'].split('.')))
+    return list(map(int, filter(lambda k: k in '0123456789.', x['version']).split('.')))
 
 def _get_from_http(repo_url, file_url, **kwargs):
     """Downloads the Chart's repo index from HTTP(S)"""

--- a/pyhelm/repo.py
+++ b/pyhelm/repo.py
@@ -46,7 +46,7 @@ class RepositoryError(RuntimeError):
 
 
 def _semver_sorter(x):
-    return list(map(int, ''.join(i for i in x['version'] if i in '012345678.').split('.')))
+    return list(map(int, ''.join(i for i in x['version'] if i in '0123456789.').split('.')))
 
 def _get_from_http(repo_url, file_url, **kwargs):
     """Downloads the Chart's repo index from HTTP(S)"""

--- a/pyhelm/repo.py
+++ b/pyhelm/repo.py
@@ -46,7 +46,7 @@ class RepositoryError(RuntimeError):
 
 
 def _semver_sorter(x):
-    return list(map(int, filter(lambda k: k in '0123456789.', x['version']).split('.')))
+    return list(map(int, ''.join(i for i in x['version'] if i in '012345678.').split('.')))
 
 def _get_from_http(repo_url, file_url, **kwargs):
     """Downloads the Chart's repo index from HTTP(S)"""


### PR DESCRIPTION
This strips non-numeric/non-dot characters in the semver sorter. This is intended to cope with version strings like "v1.2.3".