### PR TITLE
Fix TypeError on get_files and get_templates functions - Closes #57

### DIFF
--- a/pyhelm/chartbuilder.py
+++ b/pyhelm/chartbuilder.py
@@ -149,7 +149,8 @@ class ChartBuilder(object):
                 filename = filename.replace("\\", "/")
 
                 with open(os.path.join(root, file), "r") as fd:
-                    chart_files.append(Any(type_url=filename, value=fd.read()))
+                    chart_files.append(Any(type_url=filename,
+                                           value=fd.read().encode()))
 
         return chart_files
 
@@ -197,7 +198,7 @@ class ChartBuilder(object):
                 templates.append(Template(name=template_name,
                                           data=open(os.path.join(root,
                                                                  tpl_file),
-                                                    'r').read()))
+                                                    'r').read().encode()))
         return templates
 
     def get_helm_chart(self):


### PR DESCRIPTION
Fix for issue #57 - calling encode() to convert string to bytes.