### PR TITLE
Resolve character encoding issues in chartbuilder.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,10 +14,10 @@ In order to install a Helm chart using PyHelm, you can perform the following ste
 
     from pyhelm.chartbuilder import ChartBuilder
 
-    chart = ChartBuilder({"name": "nginx-ingress", "source": {"type": "repo", "location": "https://kubernetes-charts.storage.googleapis.com"}}) 
-    
-This will cause the chart to cloned locally, and any additional use of ``chart`` will reference the local copy.
-You can also used a local chart by using ``"type": "directory"``, as well as cloning from a git repo using ``"type": "git"``
+    chart = ChartBuilder({"name": "nginx-ingress", "source": {"type": "repo", "location": "https://kubernetes-charts.storage.googleapis.com"}})
+
+This will cause the chart to be cloned locally, and any additional use of ``chart`` will reference the local copy.
+You can also use a local chart by using ``"type": "directory"``, as well as cloning from a git repo using ``"type": "git"``
 
 **Installing a chart**
 
@@ -27,11 +27,11 @@ You can also used a local chart by using ``"type": "directory"``, as well as clo
     from pyhelm.tiller import Tiller
 
     tiller = Tiller(TILLER_HOST)
-    chart = ChartBuilder({"name": "nginx-ingress", "source": {"type": "repo", "location": "https://kubernetes-charts.storage.googleapis.com"}}) 
+    chart = ChartBuilder({"name": "nginx-ingress", "source": {"type": "repo", "location": "https://kubernetes-charts.storage.googleapis.com"}})
     tiller.install_release(chart.get_helm_chart(), dry_run=False, namespace='default')
 
 This snippet will install the ``nginx-ingress`` chart on a Kubernetes cluster where Tiller is installed (assuming ``TILLER_HOST`` points to a live Tiller instance). Take note that in most Helm installations Tiller isn't accessible in such a manner, and you will need to perform a Kubernetes port-forward operation to access Tiller.
-The ``Tiller`` class supports other operations other than installation, including release listing, release updating, release uninstallation and getting release contents.
+The ``Tiller`` class supports operations other than installation, including release listing, release updating, release uninstallation and getting release contents.
 
 Helm gRPC
 ---------

--- a/pyhelm/chartbuilder.py
+++ b/pyhelm/chartbuilder.py
@@ -1,6 +1,7 @@
 import pyhelm.logger as logger
 import os
 import yaml
+import codecs
 
 from hapi.services.tiller_pb2 import GetReleaseContentRequest
 from hapi.chart.template_pb2 import Template
@@ -111,7 +112,7 @@ class ChartBuilder(object):
         Process metadata
         '''
         # extract Chart.yaml to construct metadata
-        with open(os.path.join(self.source_directory, 'Chart.yaml')) as fd:
+        with codecs.open(os.path.join(self.source_directory, 'Chart.yaml')) as fd:
             chart_yaml = dotify(yaml.safe_load(fd.read()))
 
         # construct Metadata object
@@ -148,8 +149,8 @@ class ChartBuilder(object):
                 # from a Windows machine the lookup will fail.
                 filename = filename.replace("\\", "/")
 
-                with open(os.path.join(root, file), "r") as fd:
-                    chart_files.append(Any(type_url=filename, value=fd.read().encode()))
+                with codecs.open(os.path.join(root, file), "r") as fd:
+                    chart_files.append(Any(type_url=filename, value=fd.read()))
 
         return chart_files
 
@@ -160,7 +161,7 @@ class ChartBuilder(object):
 
         # create config object representing unmarshaled values.yaml
         if os.path.exists(os.path.join(self.source_directory, 'values.yaml')):
-            with open(os.path.join(self.source_directory, 'values.yaml')) as fd:
+            with codecs.open(os.path.join(self.source_directory, 'values.yaml')) as fd:
                 raw_values = fd.read()
         else:
             self._logger.warn("No values.yaml in %s, using empty values",
@@ -195,9 +196,9 @@ class ChartBuilder(object):
                 template_name = template_name.replace("\\", "/")
 
                 templates.append(Template(name=template_name,
-                                          data=open(os.path.join(root,
+                                          data=codecs.open(os.path.join(root,
                                                                  tpl_file),
-                                                    'r').read().encode()))
+                                                    'r').read()))
         return templates
 
     def get_helm_chart(self):


### PR DESCRIPTION
This pull request resolves the issue reported in #65 by using the Python [Codecs](https://docs.python.org/2/library/codecs.html#module-codecs) module. This should remove the need to do any explicit `encode()` or `decode()` steps within the code.

I also updated a couple of typos I spotted in the `README.md` whilst I was at it 🙂