### PR TITLE
Force `appVersion` and `version` to be cast as strings

### DIFF
--- a/pyhelm/chartbuilder.py
+++ b/pyhelm/chartbuilder.py
@@ -127,8 +127,8 @@ class ChartBuilder(object):
             apiVersion=default_chart_yaml['apiVersion'],
             description=default_chart_yaml['description'],
             name=default_chart_yaml['name'],
-            version=default_chart_yaml['version'],
-            appVersion=default_chart_yaml['appVersion']
+            version=str(default_chart_yaml['version']),
+            appVersion=str(default_chart_yaml['appVersion'])
         )
 
     def get_files(self):

--- a/tests/test_chartbuilder.py
+++ b/tests/test_chartbuilder.py
@@ -42,6 +42,7 @@ apiVersion: v1
 kind: Deployment
 metadata:
   name: {{ include "foo.fullname" . }}
+  testdata: testing_dodgy_encoding
   namespace: "{{ .Values.namespace }}"
 ''')
 
@@ -92,13 +93,13 @@ metadata:
         cb._logger.info.assert_called()
         cb._logger.exception.assert_not_called()
 
-    @mock.patch('pyhelm.chartbuilder.open', return_value=_chart)
+    @mock.patch('pyhelm.chartbuilder.codecs.open', return_value=_chart)
     @mock.patch(_mock_source_clone, return_value='')
     def test_get_metadata(self, _0, _1):
         m = ChartBuilder({}).get_metadata()
         self.assertIsInstance(m, Metadata)
 
-    @mock.patch('pyhelm.chartbuilder.open', return_value=_file)
+    @mock.patch('pyhelm.chartbuilder.codecs.open', return_value=_file)
     @mock.patch('pyhelm.chartbuilder.os.walk', return_value=_files_walk)
     @mock.patch(_mock_source_clone, return_value='test')
     def test_get_files(self, _0, _1, _2):
@@ -111,14 +112,14 @@ metadata:
         ChartBuilder({}).get_values()
         ChartBuilder._logger.warn.assert_called()
 
-    @mock.patch('pyhelm.chartbuilder.open', return_value=_values)
+    @mock.patch('pyhelm.chartbuilder.codecs.open', return_value=_values)
     @mock.patch('pyhelm.chartbuilder.os.path.exists', return_value=True)
     @mock.patch(_mock_source_clone, return_value='test')
     def test_get_values(self, _0, _1, _2):
         v = ChartBuilder({}).get_values()
         self.assertIsInstance(v, Config)
 
-    @mock.patch('pyhelm.chartbuilder.open', return_value=_template)
+    @mock.patch('pyhelm.chartbuilder.codecs.open', return_value=_template)
     @mock.patch('pyhelm.chartbuilder.os.walk', return_value=_templates_walk)
     @mock.patch(_mock_source_clone, return_value='test')
     def test_get_templates(self, _0, _1, _2):

--- a/tests/test_chartbuilder.py
+++ b/tests/test_chartbuilder.py
@@ -42,7 +42,6 @@ apiVersion: v1
 kind: Deployment
 metadata:
   name: {{ include "foo.fullname" . }}
-  testdata: testing_dodgy_encoding
   namespace: "{{ .Values.namespace }}"
 ''')
 
@@ -145,6 +144,13 @@ metadata:
 
     @mock.patch('pyhelm.chartbuilder.repo')
     def test_source_cleanup(self, mock_repo):
+        ChartBuilder({'name': 'foo',
+                      'source': {'type': 'directory', 'location': 'test'}}
+                     ).source_cleanup()
+        mock_repo.source_cleanup.assert_called()
+
+    # @mock.patch('pyhelm.chartbuilder.repo')
+    def test_foreign_encodings(self, mock_repo):
         ChartBuilder({'name': 'foo',
                       'source': {'type': 'directory', 'location': 'test'}}
                      ).source_cleanup()


### PR DESCRIPTION
This is to fix situation where `appVersion` or `version` are
not wrapped in quote marks, and may be interpreted as other
types, causing an TypeError. For instance, 7.0 is seen as a float

This is related to https://github.com/flaper87/pyhelm/issues/64