### PR TITLE
Add and use new read_file() to handle reads in a stable manner

### DIFF
--- a/pyhelm/chartbuilder.py
+++ b/pyhelm/chartbuilder.py
@@ -1,6 +1,7 @@
 import pyhelm.logger as logger
 import os
 import yaml
+import codecs
 
 from hapi.services.tiller_pb2 import GetReleaseContentRequest
 from hapi.chart.template_pb2 import Template
@@ -112,8 +113,7 @@ class ChartBuilder(object):
         Process metadata
         '''
         # extract Chart.yaml to construct metadata
-        with open(os.path.join(self.source_directory, 'Chart.yaml')) as fd:
-            chart_yaml = yaml.safe_load(fd.read())
+        chart_yaml = yaml.safe_load(self.read_file(os.path.join(self.source_directory, 'Chart.yaml')))
 
         if 'version' not in chart_yaml or \
            'name' not in chart_yaml:
@@ -127,8 +127,8 @@ class ChartBuilder(object):
             apiVersion=default_chart_yaml['apiVersion'],
             description=default_chart_yaml['description'],
             name=default_chart_yaml['name'],
-            version=default_chart_yaml['version'],
-            appVersion=default_chart_yaml['appVersion']
+            version=str(default_chart_yaml['version']),
+            appVersion=str(default_chart_yaml['appVersion'])
         )
 
     def get_files(self):
@@ -158,8 +158,8 @@ class ChartBuilder(object):
                 # from a Windows machine the lookup will fail.
                 filename = filename.replace("\\", "/")
 
-                with open(os.path.join(root, file), "r") as fd:
-                    chart_files.append(Any(type_url=filename, value=fd.read().encode()))
+                chart_files.append(Any(type_url=filename, value=self.read_file(os.path.join(root, file))))
+
 
         return chart_files
 
@@ -170,8 +170,7 @@ class ChartBuilder(object):
 
         # create config object representing unmarshaled values.yaml
         if os.path.exists(os.path.join(self.source_directory, 'values.yaml')):
-            with open(os.path.join(self.source_directory, 'values.yaml')) as fd:
-                raw_values = fd.read()
+            raw_values = self.read_file(os.path.join(self.source_directory, 'values.yaml'))
         else:
             self._logger.warn("No values.yaml in %s, using empty values",
                               self.source_directory)
@@ -205,9 +204,7 @@ class ChartBuilder(object):
                 template_name = template_name.replace("\\", "/")
 
                 templates.append(Template(name=template_name,
-                                          data=open(os.path.join(root,
-                                                                 tpl_file),
-                                                    'r').read().encode()))
+                                          data=self.read_file(os.path.join(root,tpl_file))))
         return templates
 
     def get_helm_chart(self):
@@ -235,6 +232,15 @@ class ChartBuilder(object):
 
         self._helm_chart = helm_chart
         return helm_chart
+
+    def read_file(self, path):
+        '''
+        Open the file provided in `path` and strip any non-UTF8 characters.
+        Return back the cleaned content
+        '''
+        content = codecs.open(path, encoding='utf-8', errors='ignore').read()
+        return bytes(bytearray(content, encoding='utf-8'))
+
 
     def dump(self):
         '''

--- a/tests/test_chartbuilder.py
+++ b/tests/test_chartbuilder.py
@@ -92,13 +92,13 @@ metadata:
         cb._logger.info.assert_called()
         cb._logger.exception.assert_not_called()
 
-    @mock.patch('pyhelm.chartbuilder.open', return_value=_chart)
+    @mock.patch('pyhelm.chartbuilder.codecs.open', return_value=_chart)
     @mock.patch(_mock_source_clone, return_value='')
     def test_get_metadata(self, _0, _1):
         m = ChartBuilder({}).get_metadata()
         self.assertIsInstance(m, Metadata)
 
-    @mock.patch('pyhelm.chartbuilder.open', return_value=_file)
+    @mock.patch('pyhelm.chartbuilder.codecs.open', return_value=_file)
     @mock.patch('pyhelm.chartbuilder.os.walk', return_value=_files_walk)
     @mock.patch(_mock_source_clone, return_value='test')
     def test_get_files(self, _0, _1, _2):
@@ -111,14 +111,14 @@ metadata:
         ChartBuilder({}).get_values()
         ChartBuilder._logger.warn.assert_called()
 
-    @mock.patch('pyhelm.chartbuilder.open', return_value=_values)
+    @mock.patch('pyhelm.chartbuilder.codecs.open', return_value=_values)
     @mock.patch('pyhelm.chartbuilder.os.path.exists', return_value=True)
     @mock.patch(_mock_source_clone, return_value='test')
     def test_get_values(self, _0, _1, _2):
         v = ChartBuilder({}).get_values()
         self.assertIsInstance(v, Config)
 
-    @mock.patch('pyhelm.chartbuilder.open', return_value=_template)
+    @mock.patch('pyhelm.chartbuilder.codecs.open', return_value=_template)
     @mock.patch('pyhelm.chartbuilder.os.walk', return_value=_templates_walk)
     @mock.patch(_mock_source_clone, return_value='test')
     def test_get_templates(self, _0, _1, _2):


### PR DESCRIPTION
File content reads were being handled differently in four separate
places in the original script. These have been switched to use a
standard function `read_file()` which performs the same content
clean-up and conversion every time, and copes with foreign file
encodings consistently.

`test_chartbuilder.py` has been updated to use the codecs.open()
method also

This is as a fix for https://github.com/flaper87/pyhelm/issues/65