### PR TITLE
Force `appVersion` and `version` to be cast as strings

### DIFF
--- a/pyhelm/chartbuilder.py
+++ b/pyhelm/chartbuilder.py
@@ -127,8 +127,8 @@ class ChartBuilder(object):
             apiVersion=default_chart_yaml['apiVersion'],
             description=default_chart_yaml['description'],
             name=default_chart_yaml['name'],
-            version=default_chart_yaml['version'],
-            appVersion=default_chart_yaml['appVersion']
+            version=str(default_chart_yaml['version']),
+            appVersion=str(default_chart_yaml['appVersion'])
         )
 
     def get_files(self):


### PR DESCRIPTION
This is to fix situation where `appVersion` or `version` are
not wrapped in quote marks, and may be interpreted as other
types, causing an TypeError. For instance, 7.0 is seen as a float

This is related to #64