### PR TITLE
Remove references to Python 3.5

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,6 @@ classifier =
     Programming Language :: Python :: 2
     Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36,py37,coverage
+envlist = py27,py36,py37,coverage
 
 [testenv]
 deps =


### PR DESCRIPTION
As discussed on the issue linked below, the current tests will not work for Python 3.5 as they use a method that doesn't exist in that version. Removing support for Python 3.5 and excluding that version from Tox / setup.cfg

https://github.com/flaper87/pyhelm/issues/73