### PR TITLE
[tiller] Adjust gRPC max send limit

### DIFF
--- a/pyhelm/tiller.py
+++ b/pyhelm/tiller.py
@@ -15,6 +15,7 @@ TILLER_TIMEOUT = 300
 RELEASE_LIMIT = 32
 DEFAULT_NAMESPACE = "default"
 GRPC_MAX_RECEIVE_MESSAGE_LENGTH = 1024*1024*50
+GRPC_MAX_SEND_MESSAGE_LENGTH = 1024*1024*20
 GRPC_KEEPALIVE_TIME_MS = 60000
 GRPC_MIN_TIME_BETWEEN_PINGS_MS = 60000
 
@@ -60,7 +61,8 @@ class Tiller(object):
             ("grpc.http2.min_time_between_pings_ms", GRPC_MIN_TIME_BETWEEN_PINGS_MS),
             ("grpc.http2.max_pings_without_data", 0),
             ("grpc.keepalive_permit_without_calls", 1),
-            ("grpc.max_receive_message_length", GRPC_MAX_RECEIVE_MESSAGE_LENGTH)
+            ("grpc.max_receive_message_length", GRPC_MAX_RECEIVE_MESSAGE_LENGTH),
+            ("grpc.max_send_message_length", GRPC_MAX_SEND_MESSAGE_LENGTH)
         )
 
         if self._tls_config:


### PR DESCRIPTION
Max send limit for gRPC channel in tiller is now adjusted to 20MB. This matches the default setting in Helm.