### PR TITLE
Add support for storing charts in GCS.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ requests
 PyYAML
 boto3
 botocore
+google-cloud-storage==1.20.0

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -110,3 +110,25 @@ entries:
             {'Error': {'Code': ''}}, '')
         with self.assertRaises(ClientError):
             repo._get_from_repo('s3', 'test', 'foo')
+
+    def test_get_from_gcs_ok(self, mocked_gcsclient):
+        repo._get_from_repo('gcs', 'test', 'bar')
+        mocked_gcsclient.return_value.get_object.assert_called()
+
+    def test_get_from_gcs_repo_error(self, mocked_gcsclient):
+        mocked_gcsclient.return_value.get_object.side_effect = ClientError(
+            {'Error': {'Code': 'NoSuchBucket'}}, '')
+        with self.assertRaises(repo.RepositoryError):
+            repo._get_from_repo('gcs', 'test', 'foo')
+
+    def test_get_from_gcs_chart_error(self, mocked_gcsclient):
+        mocked_gcsclient.return_value.get_object.side_effect = ClientError(
+            {'Error': {'Code': 'NoSuchKey'}}, '')
+        with self.assertRaises(repo.ChartError):
+            repo._get_from_repo('gcs', 'test', 'foo')
+
+    def test_get_from_gcs_client_error(self, mocked_gcsclient):
+        mocked_gcsclient.return_value.get_object.side_effect = ClientError(
+            {'Error': {'Code': ''}}, '')
+        with self.assertRaises(ClientError):
+            repo._get_from_repo('gcs', 'test', 'foo')


### PR DESCRIPTION
- Charts can be in public or private GCS buckets. Uses APPLICATION_DEFAULT_CREDENTIALS to authenticate
- Usage:

```
chart_options = {
    "name":"my-chart",
    "source": {
    	"type": "repo",
        "location": f"gs://{bucket_name}"

     }
}

chart = ChartBuilder(chart_options)